### PR TITLE
Deliver a sitemap file inline, not as an attachment

### DIFF
--- a/project-code/app/com/edulify/modules/sitemap/SitemapController.java
+++ b/project-code/app/com/edulify/modules/sitemap/SitemapController.java
@@ -16,7 +16,7 @@ public class SitemapController extends Controller {
     File sitemapFile = new File(baseDir, sitemap);
     play.Logger.debug("Delivering sitemap file " + sitemapFile.getAbsolutePath());
     if(canDelivery(sitemapFile)) {
-      return ok(sitemapFile);
+      return ok(sitemapFile, true);
     }
     if ("_index".equals(sitemapSuffix)) {
       return sitemap("");


### PR DESCRIPTION
When opening the sitemap I get a dialog to download the file.
Instead I just want to view the file, not download it.
