### PR TITLE
Fix java.lang.InstantiationException and NoSuchMethodException

### DIFF
--- a/app/com/edulify/modules/sitemap/AnnotationUrlProvider.java
+++ b/app/com/edulify/modules/sitemap/AnnotationUrlProvider.java
@@ -15,6 +15,8 @@ import org.reflections.scanners.MethodAnnotationsScanner;
 import play.Configuration;
 import play.mvc.Call;
 
+import scala.Function0;
+
 import javax.inject.Inject;
 
 public class AnnotationUrlProvider implements UrlProvider {
@@ -63,7 +65,9 @@ public class AnnotationUrlProvider implements UrlProvider {
       String methodName = method.getName();
       Class<?> clazz    = classLoader.loadClass(String.format("controllers.Reverse%s", className));
       Method reverseMethod = clazz.getMethod(methodName);
-      Call call = (Call) reverseMethod.invoke(clazz.newInstance());
+      Class<?> routesPrefixClazz = classLoader.loadClass("router.RoutesPrefix");
+      Method byNamePrefixMethod = routesPrefixClazz.getMethod("byNamePrefix");
+      Call call = (Call) reverseMethod.invoke(clazz.getConstructor(Function0.class).newInstance(byNamePrefixMethod.invoke(routesPrefixClazz)));
       itemUrl = call.url();
     } catch (ClassNotFoundException ex) {
       play.Logger.error("Package controllers does not have such class", ex);


### PR DESCRIPTION
This fixes:
```
java.lang.InstantiationException: controllers.ReverseApplication
	at java.lang.Class.newInstance(Class.java:427) ~[na:1.8.0_45]
```
and any `java.lang.NoSuchMethodException`s.

The problem is there is no zero-argument constructor anymore, the constructor of any `controllers.Reverse*` class takes a `scala.Function0` argument now. Therefore we pass the result of `router.RoutesPrefix.byNamePrefix()`. (This is how any `controllers.Reverse*` object gets instantiate in `target/scala-2.11/routes/main/controllers/routes.java` as well.)

@megazord  If you need info or help let me know. Anything else which holds back a new release?