### PR TITLE
initialDelay and executionInterval included in "complete example" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ sitemap {
   }
   baseUrl   = "http://localhost:9000"
   providers = "sitemap.providers.ArticlesUrlProvider"
+  initialDelay = "1 minute"
+  executionInterval = "2 hours"
 }
 
 akka {


### PR DESCRIPTION
I see that I forgot to put these in ```complete example``` section - sorry